### PR TITLE
Fix failing `tidetools` test

### DIFF
--- a/SalishSeaTools/salishsea_tools/tidetools.py
+++ b/SalishSeaTools/salishsea_tools/tidetools.py
@@ -1275,7 +1275,7 @@ def get_current_harms(runname, loc):
 
 
 def get_run_length(runname, loc):
-    """Get the length of the run in days from the namelist file
+    """Get the length, in days, of the run from the namelist file
 
     :arg runname: name of the model run to process; e.g. '50s_15Sep-21Sep'
     :type runname: str

--- a/SalishSeaTools/tests/test_tidetools.py
+++ b/SalishSeaTools/tests/test_tidetools.py
@@ -17,81 +17,82 @@
 """
 from __future__ import division
 
-from unittest.mock import (
-    mock_open,
-    patch,
-)
+import textwrap
 import numpy as np
 
 from salishsea_tools import tidetools
 
 
-def test_get_run_length():
-    m_open = mock_open()
-    m_open().__iter__.return_value = '''
-!! Run timing control
-!!
-!! *Note*: The time step is set in the &namdom namelist in the namelist.domain
-!!         file.
-!!
-&namrun        !   Parameters of the run
-!-----------------------------------------------------------------------
-   cn_exp      = "SalishSea"  ! experience name
-   nn_it000    =           1  ! first time step
-   nn_itend    =       12096  ! last time step (std 1 day = 8640 re: rn_rdt in &namdom)
-   nn_date0    =    20020915  ! date at nit_0000 = 1 (format yyyymmdd)
-                              ! used to adjust tides to run date (regardless of restart control)
-   nn_leapy    =       1      ! Leap year calendar (1) or not (0)
-   ln_rstart   =  .true.      ! start from rest (F) or from a restart file (T)
-   nn_rstctl   =       2      ! restart control => activated only if ln_rstart = T
-                              !   = 0 nn_date0 read in namelist
-                              !       nn_it000 read in namelist
-                              !   = 1 nn_date0 read in namelist
-                              !       nn_it000 check consistency between namelist and restart
-                              !   = 2 nn_date0 read in restart
-                              !       nn_it000 check consistency between namelist and restart
-   nn_istate   =       0      ! output the initial state (1) or not (0)
-   nn_stock    =   12096      ! frequency of creation of a restart file (modulo referenced to 1)
-   ln_clobber  =  .true.      ! clobber (overwrite) an existing file
-&end
-
-&nam_diaharm   !   Harmonic analysis of tidal constituents ('key_diaharm')
-!-----------------------------------------------------------------------
-    nit000_han =  8641  ! First time step used for harmonic analysis
-    nitend_han = 12096  ! Last time step used for harmonic analysis
-    nstep_han  =      90  ! Time step frequency for harmonic analysis
-    !! Names of tidal constituents
-    tname(1)   = 'K1'
-    tname(2)   = 'M2'
-&end
-
-
-!! Domain configuration
-!!
-&namzgr        !   vertical coordinates
-!-----------------------------------------------------------------------
-   ln_zco      = .false.   !  z-coordinate - full    steps   (T/F)      ("key_zco" may also be defined)
-   ln_zps      = .true.    !  z-coordinate - partial steps   (T/F)
-&end
-
-&namdom        !   space and time domain (bathymetry, mesh, timestep)
-!-----------------------------------------------------------------------
-   nn_bathy    =    1      !  compute (=0) or read (=1) the bathymetry file
-   nn_msh      =    0      !  create (=1) a mesh file or not (=0)
-   rn_hmin     =    3.     !  min depth of the ocean (>0) or min number of ocean level (<0)
-   rn_e3zps_min=    5.     !  partial step thickness is set larger than the minimum of
-   rn_e3zps_rat=    0.2    !  rn_e3zps_min and rn_e3zps_rat*e3t, with 0<rn_e3zps_rat<1
-                           !
-   rn_rdt      =   50.     !  time step for the dynamics (and tracer if nn_acc=0)
-   nn_baro     =    5      !  number of barotropic time step            ("key_dynspg_ts")
-   rn_atfp     =    0.1    !  asselin time filter parameter
-   nn_acc      =    0      !  acceleration of convergence : =1      used, rdt < rdttra(k)
-                           !                                =0, not used, rdt = rdttra
-   rn_rdtmin   =   300.    !  minimum time step on tracers (used if nn_acc=1)
-   rn_rdtmax   =   300.    !  maximum time step on tracers (used if nn_acc=1)
-   rn_rdth     =  300.     !  depth variation of tracer time step  (used if nn_acc=1)
-&end
-        '''.splitlines()
-    with patch('salishsea_tools.tidetools.namelist.open', m_open, create=True):
-        run_length = tidetools.get_run_length('foo', 'bar')
+def test_get_run_length(tmp_path):
+    runname = "test_run"
+    run_dir = tmp_path / runname
+    run_dir.mkdir()
+    test_namelist = run_dir / 'namelist'
+    test_namelist.write_text(textwrap.dedent(
+        '''
+        !! Run timing control
+        !!
+        !! *Note*: The time step is set in the &namdom namelist in the namelist.domain
+        !!         file.
+        !!
+        &namrun        !   Parameters of the run
+        !-----------------------------------------------------------------------
+           cn_exp      = "SalishSea"  ! experience name
+           nn_it000    =           1  ! first time step
+           nn_itend    =       12096  ! last time step (std 1 day = 8640 re: rn_rdt in &namdom)
+           nn_date0    =    20020915  ! date at nit_0000 = 1 (format yyyymmdd)
+                                      ! used to adjust tides to run date (regardless of restart control)
+           nn_leapy    =       1      ! Leap year calendar (1) or not (0)
+           ln_rstart   =  .true.      ! start from rest (F) or from a restart file (T)
+           nn_rstctl   =       2      ! restart control => activated only if ln_rstart = T
+                                      !   = 0 nn_date0 read in namelist
+                                      !       nn_it000 read in namelist
+                                      !   = 1 nn_date0 read in namelist
+                                      !       nn_it000 check consistency between namelist and restart
+                                      !   = 2 nn_date0 read in restart
+                                      !       nn_it000 check consistency between namelist and restart
+           nn_istate   =       0      ! output the initial state (1) or not (0)
+           nn_stock    =   12096      ! frequency of creation of a restart file (modulo referenced to 1)
+           ln_clobber  =  .true.      ! clobber (overwrite) an existing file
+        &end
+        
+        &nam_diaharm   !   Harmonic analysis of tidal constituents ('key_diaharm')
+        !-----------------------------------------------------------------------
+            nit000_han =  8641  ! First time step used for harmonic analysis
+            nitend_han = 12096  ! Last time step used for harmonic analysis
+            nstep_han  =      90  ! Time step frequency for harmonic analysis
+            !! Names of tidal constituents
+            tname(1)   = 'K1'
+            tname(2)   = 'M2'
+        &end
+        
+        
+        !! Domain configuration
+        !!
+        &namzgr        !   vertical coordinates
+        !-----------------------------------------------------------------------
+           ln_zco      = .false.   !  z-coordinate - full    steps   (T/F)      ("key_zco" may also be defined)
+           ln_zps      = .true.    !  z-coordinate - partial steps   (T/F)
+        &end
+        
+        &namdom        !   space and time domain (bathymetry, mesh, timestep)
+        !-----------------------------------------------------------------------
+           nn_bathy    =    1      !  compute (=0) or read (=1) the bathymetry file
+           nn_msh      =    0      !  create (=1) a mesh file or not (=0)
+           rn_hmin     =    3.     !  min depth of the ocean (>0) or min number of ocean level (<0)
+           rn_e3zps_min=    5.     !  partial step thickness is set larger than the minimum of
+           rn_e3zps_rat=    0.2    !  rn_e3zps_min and rn_e3zps_rat*e3t, with 0<rn_e3zps_rat<1
+                                   !
+           rn_rdt      =   50.     !  time step for the dynamics (and tracer if nn_acc=0)
+           nn_baro     =    5      !  number of barotropic time step            ("key_dynspg_ts")
+           rn_atfp     =    0.1    !  asselin time filter parameter
+           nn_acc      =    0      !  acceleration of convergence : =1      used, rdt < rdttra(k)
+                                   !                                =0, not used, rdt = rdttra
+           rn_rdtmin   =   300.    !  minimum time step on tracers (used if nn_acc=1)
+           rn_rdtmax   =   300.    !  maximum time step on tracers (used if nn_acc=1)
+           rn_rdth     =  300.     !  depth variation of tracer time step  (used if nn_acc=1)
+        &end
+        '''
+    ))
+    run_length = tidetools.get_run_length('test_run', test_namelist.parent.parent)
     np.testing.assert_almost_equal(run_length, 2)


### PR DESCRIPTION
## Summary
This Pull Request includes changes focused on enhancing the failing test for the `tidetools.get_run_length` function, within the **Salish Sea tools project**. Specifically, this refines the structure of the unit test and solves reliability issues.

- Refactored the `test_get_run_length` function by using the `tmp_path` strategy to dynamically create a temporary directory and namelist file.
- Introduced the `textwrap.dedent` module for better formatting of test data in the test.
- Removed mocked operations (`mock_open`, `patch`) and replaced them with a `tmp_path`-based approach to improve test reliability during filesystem interactions.Refactor and enhance `get_run_length` test logic
