### PR TITLE
Enable SalishSeaTools editable install in dev env

### DIFF
--- a/SalishSeaTools/docs/development.rst
+++ b/SalishSeaTools/docs/development.rst
@@ -59,7 +59,8 @@ Development Environment
 
 Setting up an isolated development environment using `Conda`_ is recommended.
 Assuming that you have `Miniconda`_ installed,
-you can create and activate an environment called :kbd:`salishsea-tools` that will have all of the Python packages necessary for development,
+you can create and activate an environment called :kbd:`salishsea-tools` that will have
+all of the Python packages necessary for development,
 testing,
 and building the documentation with the commands:
 
@@ -71,10 +72,13 @@ and building the documentation with the commands:
     $ cd tools
     $ conda env create -f SalishSeaTools/envs/environment-dev.yaml
     $ conda activate salishsea-tools
-    (salishsea-tools)$ pip install --editable SalishSeaTools
 
-The :kbd:`--editable` option in the :command:`pip install` commands above installs the :kbd:`SalishSeaTools` from the cloned repo via symlinks so that it will be automatically updated as the repos evolve.
+:kbd:`SalishSeaTools` is installed in `editable install mode`_ as part of the conda environment
+creation process.
+That means that the package is installed from the cloned repo via symlinks so that
+it will be automatically updated as the repo evolves.
 
+.. _editable install mode: https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs
 To deactivate the environment use:
 
 .. code-block:: bash

--- a/SalishSeaTools/docs/installation.rst
+++ b/SalishSeaTools/docs/installation.rst
@@ -36,7 +36,7 @@ To install the :kbd:`SalishSeaTools` package in your :kbd:`root` Anaconda or Min
 .. code-block:: bash
 
     $ cd tools
-    $ pip install --editable SalishSeaTools
+    $ python -m pip install --editable SalishSeaTools
 
 The :kbd:`--editable` option in the :command:`pip install` commands installs the packages via symlinks so that changes in the package modules will be automatically available in your working environment as the repo evolves.
 

--- a/SalishSeaTools/envs/environment-dev.yaml
+++ b/SalishSeaTools/envs/environment-dev.yaml
@@ -7,7 +7,6 @@
 #   $ cd tools
 #   $ conda env create -f SalishSeaTools/envs/environment-dev.yaml
 #   $ conda activate salishsea-tools
-#   (salishsea-tools)$ python -m pip install --editable SalishSeaTools
 #
 # See the envs/requirements.txt file for an exhaustive list of all the
 # packages installed in the environment and their versions used in
@@ -58,3 +57,6 @@ dependencies:
 
   - pip:
     - angles
+
+    # Install the SalishSeaTools packages in editable mode
+    - --editable ../


### PR DESCRIPTION
Updated `environment-dev.yaml` to include editable installation of SalishSeaTools during environment creation. Adjusted installation and development documentation to reflect this change and clarify the benefits of editable mode for synchronized package updates.