### PR TITLE
Add pytest-randomly to dev and test environments

### DIFF
--- a/SalishSeaTools/envs/environment-dev.yaml
+++ b/SalishSeaTools/envs/environment-dev.yaml
@@ -49,6 +49,7 @@ dependencies:
   # For unit tests
   - coverage
   - pytest-cov
+  - pytest-randomly
 
   # For documentation
   - nbsphinx==0.9.5

--- a/SalishSeaTools/envs/environment-test.yaml
+++ b/SalishSeaTools/envs/environment-test.yaml
@@ -40,6 +40,7 @@ dependencies:
   # For unit tests and coverage monitoring
   - coverage
   - pytest-cov
+  - pytest-randomly
 
   # For documentation links checking
   - sphinx=8.1.3


### PR DESCRIPTION
Added pytest-randomly to environment-test.yaml and environment-dev.yaml to improve test robustness by running tests in random order. This helps detect dependencies between tests and ensures greater reliability of the test suite.