### PR TITLE
Update release process docs re: breaking changes

### DIFF
--- a/SalishSeaTools/docs/pkg_development.rst
+++ b/SalishSeaTools/docs/pkg_development.rst
@@ -257,7 +257,11 @@ The release process steps are:
 #. Use :command:`hatch version release` to bump the version from ``.devn`` to the next release
    version identifier
 
-#. Commit the version bump
+#. Confirm that :file:`tools/docs/breaking_changes.rst` includes any relevant notes for the
+   version being released
+
+#. Commit the version bump and breaking changes log update
+
 
 #. Create an annotated tag for the release with :guilabel:`Git -> New Tag...` in PyCharm
    or :command:`git tag -e -a vyy.n`

--- a/docs/breaking_changes.rst
+++ b/docs/breaking_changes.rst
@@ -24,7 +24,7 @@ Changes That Break Backward Compatibility
 
 .. _BreakingChangesVersion24.1:
 
-Version 24.1 (unreleased)
+Version 24.1 (2025-01-09)
 =========================
 
 The following changes that were introduced in version 24.1 of the ``tools`` repository


### PR DESCRIPTION
Revised the development documentation to include a step for confirming breaking changes notes before committing version bumps. Set the release date for version 24.1 in the breaking changes log.