### PR TITLE
Add explicit Sphinx configuration for readthedocs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,5 +8,10 @@ build:
 conda:
   environment: environment-rtd.yaml
 
+sphinx:
+  builder: html
+  configuration: docs/conf.py
+  fail_on_warning: false
+
 # Only build HTML and JSON formats
 formats: []


### PR DESCRIPTION
Updated `.readthedocs.yaml` to define Sphinx builder settings, including the builder type, configuration file path, and `fail_on_warning` option. This is necessary due to readthedocs deprecating projects without explicit builder configuration that comes into effect on 20-Jan-2025.