### PR TITLE
Add workflow to auto-add milestones to issues/PRs

### DIFF
--- a/.github/workflows/add-mileston-issue-pr.yaml
+++ b/.github/workflows/add-mileston-issue-pr.yaml
@@ -1,0 +1,32 @@
+name: Add Milestone to Issue/PR
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+    branches:
+      - main
+
+jobs:
+  add_milestone:
+    permissions:
+      issues: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: benelan/milestone-action@v3
+        with:
+          # If true, add the milestone with the farthest due date. By default,
+          # the action adds the current milestone (the closest due date).
+          farthest: false
+
+          # If true, overwrite existing milestones on issues and pull requests.
+          # By default, the action exits if a milestone has already been added.
+          overwrite: false
+
+          # If true, add the only open milestone in a repo, even if there is no
+          # due date. By default, milestones with no due date are ignored.
+          single: false

--- a/.github/workflows/assign-issue-pr.yaml
+++ b/.github/workflows/assign-issue-pr.yaml
@@ -1,4 +1,5 @@
 name: Assign Issue/PR
+
 on:
   issues:
     types:
@@ -8,6 +9,7 @@ on:
     types:
       - reopened
       - opened
+
 jobs:
   auto_assign:
     permissions:


### PR DESCRIPTION
Create a GitHub Actions workflow that automatically assigns milestones to newly opened issues and pull requests. This uses the `benelan/milestone-action` to manage milestones based on project configurations.