### PR TITLE
Add sphinx-notfound-page extension to docs build

### DIFF
--- a/SalishSeaTools/envs/environment-dev.yaml
+++ b/SalishSeaTools/envs/environment-dev.yaml
@@ -58,6 +58,7 @@ dependencies:
   # For documentation
   - nbsphinx==0.9.5
   - sphinx=8.1.3
+  - sphinx-notfound-page=1.0.4
   - sphinx-rtd-theme=3.0.0
 
   - pip:

--- a/SalishSeaTools/envs/environment-test.yaml
+++ b/SalishSeaTools/envs/environment-test.yaml
@@ -42,6 +42,7 @@ dependencies:
   # For documentation links checking
   - sphinx=8.1.3
   - sphinx-notfound-page=1.0.4
+  - sphinx-notfound-page=1.0.4
   - sphinx-rtd-theme=3.0.0
 
   - pip:

--- a/SalishSeaTools/envs/requirements.txt
+++ b/SalishSeaTools/envs/requirements.txt
@@ -173,6 +173,7 @@ sniffio==1.3.1
 snowballstemmer==2.2.0
 soupsieve==2.5
 Sphinx==8.1.3
+sphinx-notfound-page==1.0.4
 sphinx_rtd_theme==3.0.0
 sphinxcontrib-applehelp==2.0.0
 sphinxcontrib-devhelp==2.0.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,8 +21,9 @@ sys.path.insert(0, os.path.abspath("../SalishSeaTools"))
 # (named 'sphinx.ext.*')
 # or your custom ones.
 extensions = [
-    "nbsphinx",
     "IPython.sphinxext.ipython_console_highlighting",
+    "nbsphinx",
+    "notfound.extension",
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",

--- a/environment-rtd.yaml
+++ b/environment-rtd.yaml
@@ -15,6 +15,7 @@ dependencies:
   # Sphinx and extensions we use
   - nbsphinx==0.9.5
   - sphinx=8.1.3
+  - sphinx-notfound-page=1.0.4
   - sphinx-rtd-theme=3.0.0
 
   # readthedocs build system packages


### PR DESCRIPTION
Ensures that static assets load in the event of a 404 for a better UX. Facilitates future customization of 404 page.