### PR TITLE
Handle retirement of water level stations at Halfmoon Bay and Squamish

### DIFF
--- a/SalishSeaTools/salishsea_tools/places.py
+++ b/SalishSeaTools/salishsea_tools/places.py
@@ -147,7 +147,7 @@ PLACES = {
     },
     "Squamish": {
         "lon lat": (-123.155, 49.694),
-        "stn number": 7811,
+        "stn number": None,
         "NEMO grid ji": (532, 389),
         "wind grid ji": (162, 160),
         "ww3 grid ji": (370, 404),

--- a/SalishSeaTools/salishsea_tools/places.py
+++ b/SalishSeaTools/salishsea_tools/places.py
@@ -75,7 +75,7 @@ PLACES = {
     },
     "Halfmoon Bay": {
         "lon lat": (-123.912, 49.511),
-        "stn number": 7830,
+        "stn number": None,
         "NEMO grid ji": (549, 254),
         "wind grid ji": (158, 136),
         "ww3 grid ji": (331, 297),


### PR DESCRIPTION
Real-time water levels at Halfmoon Bay and Squamish ceased to be available from the CHS api-iwls.dfo-mpo.gc.ca water level service in August-2025. Several requests to CHS for information about the change produced no useful responses. So, we concluded that the gauges were removed.

Changing the station ids to `None` results in informative messages in response to requests via functions in `data_tools.py`,
and prevents the comparison figure failures that were occurring in the SalishSeaNowcast automation.