### PR TITLE
Add `erddapy` as a dependency and update its usage

### DIFF
--- a/SalishSeaTools/docs/api.rst
+++ b/SalishSeaTools/docs/api.rst
@@ -74,6 +74,12 @@ These API docs provide function signatures and docstrings derived directly from 
 :py:mod:`~salishsea_tools.evaltools` Module
 ===========================================
 
+Observation Loader Functions
+----------------------------
+
+.. autofunction:: salishsea_tools.evaltools.load_ferry_ERDDAP
+
+
 :py:obj:`datetime` Conversion Functions
 ---------------------------------------
 

--- a/SalishSeaTools/docs/api.rst
+++ b/SalishSeaTools/docs/api.rst
@@ -79,6 +79,8 @@ Observation Loader Functions
 
 .. autofunction:: salishsea_tools.evaltools.load_ferry_ERDDAP
 
+.. autofunction:: salishsea_tools.evaltools.load_ONC_node_ERDDAP
+
 
 :py:obj:`datetime` Conversion Functions
 ---------------------------------------

--- a/SalishSeaTools/envs/environment-dev.yaml
+++ b/SalishSeaTools/envs/environment-dev.yaml
@@ -26,6 +26,7 @@ dependencies:
   - f90nml
   - gsw
   - h5netcdf
+  - httpx
   - ipdb
   - ipython
   - jupyterlab

--- a/SalishSeaTools/envs/environment-dev.yaml
+++ b/SalishSeaTools/envs/environment-dev.yaml
@@ -22,6 +22,7 @@ dependencies:
   - arrow
   - bottleneck
   - cmocean
+  - erddapy
   - f90nml
   - gsw
   - h5netcdf

--- a/SalishSeaTools/envs/environment-test.yaml
+++ b/SalishSeaTools/envs/environment-test.yaml
@@ -18,6 +18,7 @@ dependencies:
   - f90nml
   - gsw
   - h5netcdf
+  - httpx
   - ipython
   - lxml
   - matplotlib

--- a/SalishSeaTools/envs/environment-test.yaml
+++ b/SalishSeaTools/envs/environment-test.yaml
@@ -14,6 +14,7 @@ dependencies:
   - arrow
   - bottleneck
   - cmocean
+  - erddapy
   - f90nml
   - gsw
   - h5netcdf

--- a/SalishSeaTools/envs/requirements.txt
+++ b/SalishSeaTools/envs/requirements.txt
@@ -44,6 +44,7 @@ defusedxml==0.7.1
 distlib==0.3.9
 docutils==0.21.2
 editables==0.5
+erddapy==2.2.4
 et_xmlfile==2.0.0
 exceptiongroup==1.3.0
 executing==2.2.0
@@ -55,7 +56,7 @@ fqdn==1.5.1
 gsw==3.6.19
 h11==0.16.0
 h2==4.2.0
-h5netcdf==1.6.1
+h5netcdf==1.6.2
 h5py==3.14.0
 hatch==1.14.1
 hatchling==1.27.0
@@ -150,7 +151,7 @@ PyYAML==6.0.2
 pyzmq==27.0.0
 referencing==0.36.2
 requests==2.32.4
-retrying==1.3.4
+retrying==1.4.0
 rfc3339_validator==0.1.4
 rfc3986-validator==0.1.1
 rich==14.0.0

--- a/SalishSeaTools/pyproject.toml
+++ b/SalishSeaTools/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
     "arrow",
     "bottleneck",
     "cmocean",
+    "erddapy",
     "f90nml",
     "gsw",
     "matplotlib",

--- a/SalishSeaTools/salishsea_tools/evaltools.py
+++ b/SalishSeaTools/salishsea_tools/evaltools.py
@@ -24,6 +24,7 @@ import warnings
 
 import arrow
 import cmocean as cmo
+import erddapy
 import f90nml
 import gsw
 import matplotlib.dates as mdates
@@ -2339,9 +2340,6 @@ def load_ferry_ERDDAP(datelims, variables=None):
     :rtype: :py:class:`pandas.dataframe`
     """
 
-    # load erddapy here so your can use the tools on computers without web access (sockeye)
-    from erddapy import ERDDAP
-
     server = "https://salishsea.eos.ubc.ca/erddap"
 
     protocol = "tabledap"
@@ -2371,7 +2369,7 @@ def load_ferry_ERDDAP(datelims, variables=None):
         "on_crossing_mask=": 1,
     }
 
-    obs = ERDDAP(server=server, protocol=protocol)
+    obs = erddapy.ERDDAP(server=server, protocol=protocol)
     obs.dataset_id = dataset_id
     obs.variables = variables
     obs.constraints = constraints
@@ -2414,9 +2412,6 @@ def load_ONC_node_ERDDAP(datelims, variables=None):
     :rtype: :py:class:`pandas.dataframe`
     """
 
-    # load erddapy here so your can use the tools on computers without web access (sockeye)
-    from erddapy import ERDDAP
-
     server = "https://salishsea.eos.ubc.ca/erddap"
 
     protocol = "tabledap"
@@ -2451,7 +2446,7 @@ def load_ONC_node_ERDDAP(datelims, variables=None):
     for inode, (dataset_id, node) in enumerate(zip(dataset_ids, nodes)):
         print(node, start_date, end_date)
 
-        obs = ERDDAP(server=server, protocol=protocol)
+        obs = erddapy.ERDDAP(server=server, protocol=protocol)
         obs.dataset_id = dataset_id
         obs.variables = variables
         obs.constraints = constraints

--- a/SalishSeaTools/salishsea_tools/evaltools.py
+++ b/SalishSeaTools/salishsea_tools/evaltools.py
@@ -2430,7 +2430,7 @@ def load_ONC_node_ERDDAP(datelims):
         "ubcONCLSBBLCTD15mV1",
         "ubcONCUSDDLCTD15mV1",
     ]
-    nodes = ["Central node", "Delta BBL node", "Delta DDL node", "East node"]
+    nodes = ["Central node", "East node", "Delta BBL node", "Delta DDL node"]
 
     variables = [
         "latitude",

--- a/SalishSeaTools/salishsea_tools/evaltools.py
+++ b/SalishSeaTools/salishsea_tools/evaltools.py
@@ -2328,7 +2328,27 @@ def loadHakai(datelims=(), loadCTD=False):
 
 def load_ferry_ERDDAP(datelims):
     """
+    Load ferry data from the ERDDAP server based on specified date limits.
 
+    This function retrieves environmental data (e.g., temperature, salinity, oxygen)
+    from the ERDDAP server for ferry observations within the given date range,
+    processes it, and returns a formatted pandas DataFrame. Processing includes computing
+    conservative temperature from the observed potential temperature and reference salinity,
+    conversion of oxygen concentration from ml/l to µM. The data is further
+    processed to localize timezone, rename some columns to conform with those expected by the
+    :py:func:`~salishsea_tools.evaltools.matchData` function.
+
+    :param datelims: A tuple containing two datetime or Arrow objects specifying the
+                     start and end dates for the data retrieval. The date range is inclusive.
+    :type datelims: tuple
+
+    :return: A pandas DataFrame containing the retrieved and processed environmental
+             data. The DataFrame is structured according to the expected format for
+             the :py:func:`~salishsea_tools.evaltools.matchData` function.
+    :rtype: :py:obj:`pandas.DataFrame`
+
+    :raises ValueError: If no data is found for the specified date range.
+    """
     server = "https://salishsea.eos.ubc.ca/erddap"
 
     protocol = "tabledap"
@@ -2368,7 +2388,7 @@ def load_ferry_ERDDAP(datelims):
     ).dropna()
 
     if obs_pd.empty:
-        raise ValueError('No data found for the specified date range')
+        raise ValueError("No data found for the specified date range")
 
     obs_pd["oxygen (uM)"] = 44.661 * obs_pd["o2_concentration_corrected (ml/l)"]
     obs_pd["conservative temperature (oC)"] = gsw.CT_from_pt(

--- a/SalishSeaTools/salishsea_tools/evaltools.py
+++ b/SalishSeaTools/salishsea_tools/evaltools.py
@@ -2367,6 +2367,9 @@ def load_ferry_ERDDAP(datelims):
         parse_dates=True,
     ).dropna()
 
+    if obs_pd.empty:
+        raise ValueError('No data found for the specified date range')
+
     obs_pd["oxygen (uM)"] = 44.661 * obs_pd["o2_concentration_corrected (ml/l)"]
     obs_pd["conservative temperature (oC)"] = gsw.CT_from_pt(
         obs_pd["salinity (g/kg)"], obs_pd["temperature (degrees_Celcius)"]

--- a/SalishSeaTools/salishsea_tools/evaltools.py
+++ b/SalishSeaTools/salishsea_tools/evaltools.py
@@ -2411,14 +2411,22 @@ def load_ferry_ERDDAP(datelims):
 
 
 def load_ONC_node_ERDDAP(datelims):
-    """load ONC data from the nodes from ERDDAP, return a pandas dataframe.  Do conversion on temperature to
-    conservative temperature. Pull out grid i, grid j and depth from places
+    """
+    Load data from ONC (Ocean Networks Canada) nodes via the ERDDAP server within a defined date range.
 
-    :arg datelims: start date and end date; as a 2-tuple of datetimes
+    This function fetches and processes oceanographic data from the 4 ONC nodes in the Salish Sea
+    using their respective datasets available on the ERDDAP server. It applies constraints for the
+    date range specified, handles errors in HTTP requests, processes the obtained data to adjust
+    certain attributes, and concatenates the results into a single pandas DataFrame. If no data is
+    available for the specified period, an empty DataFrame is returned.
+
+    :param datelims: Tuple of two datetime or Arrow objects objects `(start_date, end_date)`
+                     specifying the date range for querying data.
     :type datelims: tuple
 
-    :returns: variable values from ERDDAP for time period requested: as pandas dataframe
-    :rtype: :py:class:`pandas.dataframe`
+    :return: A pandas DataFrame containing the processed data for the specified nodes and
+             variables within the requested date range.
+    :rtype: :py:class:`pandas.DataFrame`
     """
 
     server = "https://salishsea.eos.ubc.ca/erddap"

--- a/SalishSeaTools/salishsea_tools/evaltools.py
+++ b/SalishSeaTools/salishsea_tools/evaltools.py
@@ -2409,15 +2409,12 @@ def load_ferry_ERDDAP(datelims):
     return obs_pd
 
 
-def load_ONC_node_ERDDAP(datelims, variables=None):
+def load_ONC_node_ERDDAP(datelims):
     """load ONC data from the nodes from ERDDAP, return a pandas dataframe.  Do conversion on temperature to
     conservative temperature. Pull out grid i, grid j and depth from places
 
     :arg datelims: start date and end date; as a 2-tuple of datetimes
     :type datelims: tuple
-
-    :arg variables: variables to pull from the ferry, see base list below; as a list of strings
-    :type variables: list
 
     :returns: variable values from ERDDAP for time period requested: as pandas dataframe
     :rtype: :py:class:`pandas.dataframe`
@@ -2434,15 +2431,14 @@ def load_ONC_node_ERDDAP(datelims, variables=None):
     ]
     nodes = ["Central node", "Delta BBL node", "Delta DDL node", "East node"]
 
-    if variables == None:
-        variables = [
-            "latitude",
-            "longitude",
-            "temperature",
-            "salinity",
-            "time",
-            "depth",
-        ]
+    variables = [
+        "latitude",
+        "longitude",
+        "temperature",
+        "salinity",
+        "time",
+        "depth",
+    ]
 
     start_date = datelims[0].strftime("%Y-%m-%dT00:00:00Z")
     end_date = datelims[1].strftime("%Y-%m-%dT00:00:00Z")

--- a/SalishSeaTools/salishsea_tools/evaltools.py
+++ b/SalishSeaTools/salishsea_tools/evaltools.py
@@ -2326,18 +2326,7 @@ def loadHakai(datelims=(), loadCTD=False):
     return fdata2
 
 
-def load_ferry_ERDDAP(datelims, variables=None):
-    """load ferry data from ERDDAP, return a pandas dataframe.  Do conversion on temperature to
-    conservative temperature, oxygen to uMol and rename grid i and grid j columns
-
-    :arg datelims: start date and end date; as a 2-tuple of datetimes
-    :type datelims: tuple
-
-    :arg variables: variables to pull from the ferry, see base list below; as a list of strings
-    :type variables: list
-
-    :returns: variable values from ERDDAP for time period requested: as pandas dataframe
-    :rtype: :py:class:`pandas.dataframe`
+def load_ferry_ERDDAP(datelims):
     """
 
     server = "https://salishsea.eos.ubc.ca/erddap"
@@ -2345,19 +2334,18 @@ def load_ferry_ERDDAP(datelims, variables=None):
     protocol = "tabledap"
     dataset_id = "ubcONCTWDP1mV18-01"
 
-    if variables == None:
-        variables = [
-            "latitude",
-            "longitude",
-            "chlorophyll",
-            "temperature",
-            "salinity",
-            "turbidity",
-            "o2_concentration_corrected",
-            "time",
-            "nemo_grid_j",
-            "nemo_grid_i",
-        ]
+    variables = [
+        "latitude",
+        "longitude",
+        "chlorophyll",
+        "temperature",
+        "salinity",
+        "turbidity",
+        "o2_concentration_corrected",
+        "time",
+        "nemo_grid_j",
+        "nemo_grid_i",
+    ]
 
     start_date = datelims[0].strftime("%Y-%m-%dT00:00:00Z")
     end_date = datelims[1].strftime("%Y-%m-%dT00:00:00Z")

--- a/SalishSeaTools/tests/test_evaltools_datetime.py
+++ b/SalishSeaTools/tests/test_evaltools_datetime.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for evaltools module."""
+"""Unit tests for evaltools module datetime conversion functions."""
 
 
 import datetime

--- a/SalishSeaTools/tests/test_evaltools_loaders.py
+++ b/SalishSeaTools/tests/test_evaltools_loaders.py
@@ -1,0 +1,145 @@
+# Copyright 2013 – present by the SalishSeaCast contributors
+# and The University of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for evaltools module data loader functions."""
+
+import arrow
+import pandas
+import pytest
+
+from salishsea_tools import evaltools
+
+
+class TestLoadFerryERDDAP:
+    """Unit tests for the evaltools.load_ferry_ERDDAP() function."""
+
+    @pytest.fixture
+    def mock_erddapy(self, monkeypatch):
+        class MockERDDAP:
+            def __init__(self, server, protocol):
+                pass
+
+            def to_pandas(self, *args, **kwargs):
+                mock_data = pandas.DataFrame(
+                    {
+                        "time (UTC)": pandas.date_range(
+                            "2025-07-01", periods=3, freq="D"
+                        ),
+                        "latitude (degrees_north)": [48.5, 48.6, 48.7],
+                        "longitude (degrees_east)": [-123.5, -123.6, -123.7],
+                        "o2_concentration_corrected (ml/l)": [1.0, 1.1, 1.2],
+                        "salinity (g/kg)": [30.0, 31.0, 32.0],
+                        "temperature (degrees_Celcius)": [10, 11, 12],
+                        "chlorophyll (ug/l)": [0, 0.5, 1.1],
+                        "turbidity (NTU)": [5, 7.3, 12.2],
+                        "nemo_grid_j (count)": [1, 2, 3],
+                        "nemo_grid_i (count)": [4, 5, 6],
+                    }
+                )
+                mock_data.set_index(["time (UTC)"], inplace=True)
+                return mock_data
+
+        monkeypatch.setattr(evaltools.erddapy, "ERDDAP", MockERDDAP)
+
+    def test_load_ferry_erddap_default_variables(self, mock_erddapy):
+        """Test loading data with the default variable list."""
+        datelims = (arrow.get("2025-07-01"), arrow.get("2025-07-03"))
+        result = evaltools.load_ferry_ERDDAP(datelims)
+
+        assert not result.empty
+        assert "dtUTC" in result.columns
+        assert "Lat" in result.columns
+        assert "Lon" in result.columns
+        assert "oxygen (uM)" in result.columns
+        assert "conservative temperature (oC)" in result.columns
+        assert "salinity (g/kg)" in result.columns
+        assert "chlorophyll (ug/l)" in result.columns
+        assert "turbidity (NTU)" in result.columns
+        assert "j" in result.columns
+        assert "i" in result.columns
+
+    def test_load_ferry_erddap_data_processing(self, mock_erddapy):
+        """Test that the data is processed correctly after loading."""
+        datelims = (arrow.get("2025-07-01"), arrow.get("2025-07-03"))
+
+        result = evaltools.load_ferry_ERDDAP(datelims)
+
+        # Verify data types and values
+        assert isinstance(result, pandas.DataFrame)
+        pandas.testing.assert_series_equal(
+            result["dtUTC"],
+            pandas.Series(
+                ["2025-07-01", "2025-07-02", "2025-07-03"],
+                dtype="datetime64[ns]",
+                name="dtUTC",
+            ),
+        )
+        pandas.testing.assert_series_equal(
+            result["Lat"], pandas.Series([48.5, 48.6, 48.7], name="Lat")
+        )
+        pandas.testing.assert_series_equal(
+            result["Lon"], pandas.Series([-123.5, -123.6, -123.7], name="Lon")
+        )
+        pandas.testing.assert_series_equal(
+            result["oxygen (uM)"],
+            pandas.Series([44.661, 1.1 * 44.661, 1.2 * 44.661], name="oxygen (uM)"),
+        )
+        pandas.testing.assert_series_equal(
+            result["conservative temperature (oC)"],
+            pandas.Series(
+                [10.083100, 11.070570, 12.055291], name="conservative temperature (oC)"
+            ),
+        )
+        pandas.testing.assert_series_equal(
+            result["salinity (g/kg)"],
+            pandas.Series([30.0, 31.0, 32.0], name="salinity (g/kg)"),
+        )
+        pandas.testing.assert_series_equal(
+            result["chlorophyll (ug/l)"],
+            pandas.Series([0.0, 0.5, 1.1], name="chlorophyll (ug/l)"),
+        )
+        pandas.testing.assert_series_equal(
+            result["turbidity (NTU)"],
+            pandas.Series([5.0, 7.3, 12.2], name="turbidity (NTU)"),
+        )
+        pandas.testing.assert_series_equal(
+            result["j"], pandas.Series([1, 2, 3], name="j")
+        )
+        pandas.testing.assert_series_equal(
+            result["i"], pandas.Series([4, 5, 6], name="i")
+        )
+
+    def test_load_ferry_erddap_empty_date_range(self, monkeypatch):
+        """Test loading data for a date range with no available data."""
+
+        class MockERDDAP:
+            def __init__(self, server, protocol):
+                pass
+
+            def to_pandas(self, *args, **kwargs):
+                mock_data = pandas.DataFrame({})
+                return mock_data
+
+        monkeypatch.setattr(evaltools.erddapy, "ERDDAP", MockERDDAP)
+
+        datelims = (arrow.get("2025-07-01"), arrow.get("2025-07-03"))
+        with pytest.raises(ValueError):
+            evaltools.load_ferry_ERDDAP(datelims)
+
+    def test_load_ferry_erddap_invalid_date_lims(self, mock_erddapy):
+        """Test loading data with invalid date limits."""
+        datelims = tuple()
+        with pytest.raises(IndexError):
+            evaltools.load_ferry_ERDDAP(datelims)

--- a/docs/breaking_changes.rst
+++ b/docs/breaking_changes.rst
@@ -40,7 +40,8 @@ are incompatible with earlier versions:
   .. _erddapy: https://ioos.github.io/erddapy/
 
 * The ``variables`` argument has been dropped from the :py:func:`evaltools.load_ferry_ERDDAP`
-  function because custom variables selection was not fully implemented.
+  and  :py:func:`evaltools.load_ONC_node_ERDDAP` functions because custom variables
+  selection was not fully implemented.
 
 
 .. _BreakingChangesVersion24.1:

--- a/docs/breaking_changes.rst
+++ b/docs/breaking_changes.rst
@@ -39,6 +39,10 @@ are incompatible with earlier versions:
 
   .. _erddapy: https://ioos.github.io/erddapy/
 
+* The ``variables`` argument has been dropped from the :py:func:`evaltools.load_ferry_ERDDAP`
+  function because custom variables selection was not fully implemented.
+
+
 .. _BreakingChangesVersion24.1:
 
 Version 24.1 (2025-01-09)

--- a/docs/breaking_changes.rst
+++ b/docs/breaking_changes.rst
@@ -33,6 +33,11 @@ are incompatible with earlier versions:
 * The minimum supported version of Python is 3.11.
   Development of the :py:obj:`SalishSeaTools` package is done using Python 3.13.
 
+* The `erddapy`_ package is now a required dependency to use the :py:mod:`evaltools` module.
+  The recommended way to add :py:obj:`erddapy` to your activated ``salishsea-tools`` environment
+  is with the command :command:`conda env update -f SalishSeaTools/envs/environment-dev.yaml`
+
+  .. _erddapy: https://ioos.github.io/erddapy/
 
 .. _BreakingChangesVersion24.1:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -49,6 +49,7 @@ autodoc_mock_imports = [
     "erddapy",
     "f90nml",
     "gsw",
+    "httpx",
     "matplotlib",
     "netCDF4",
     "nowcast",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,6 +46,7 @@ autodoc_mock_imports = [
     "angles",
     "arrow",
     "cmocean",
+    "erddapy",
     "f90nml",
     "gsw",
     "matplotlib",


### PR DESCRIPTION
Integrated `erddapy` as a required dependency in `evaltools`. Updated environment files to include `erddapy` and replaced direct imports of `ERDDAP` with `erddapy.ERDDAP`. Documented this change in the `breaking_changes.rst`.

Refactored the `evaltools.load_ferry_ERDDAP()` function and added unit tests for it.

Refactored the `evaltools.load_ONC_node_ERDDAP()` function and added unit tests for it.