### PR TITLE
Update external doc links for `numpy` and `scipy`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -35,9 +35,9 @@ intersphinx_mapping = {
     "docs": ("https://salishsea-meopar-docs.readthedocs.io/en/latest/", None),
     "salishseacmd": ("https://salishseacmd.readthedocs.io/en/latest/", None),
     "salishseanowcast": ("https://salishsea-nowcast.readthedocs.io/en/latest/", None),
-    "numpy": ("https://docs.scipy.org/doc/numpy/", None),
+    "numpy": ("https://numpy.org/doc/stable/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
-    "scipy": ("https://docs.scipy.org/doc/scipy/reference/", None),
+    "scipy": ("https://docs.scipy.org/doc/scipy/", None),
 }
 
 todo_include_todos = True


### PR DESCRIPTION
Revised the URLs for `numpy` and `scipy` documentation in `intersphinx_mapping` to point to their stable and updated documentation locations. This ensures accuracy and consistency in external references.