### PR TITLE
Fix `SyntaxWarning` and `DeprecationWarning`

### DIFF
--- a/SalishSeaTools/salishsea_tools/formatting_tools.py
+++ b/SalishSeaTools/salishsea_tools/formatting_tools.py
@@ -15,13 +15,13 @@
 
 """Functions for formatting data output from datasets."""
 
-#: String to LaTeX notation mapping for units
+# String to LaTeX notation mapping for units
 STR_LATEX_MAPPING = {
     "m/s": "m/s",
     "m2/s": "m$^2$ / s$",
-    "degrees_east": "$^\circ$E",
-    "degrees_north": "$^\circ$N",
-    "degC": "$^\circ$C",
+    "degrees_east": "$^\\circ$E",
+    "degrees_north": "$^\\circ$N",
+    "degC": "$^\\circ$C",
     "g kg-1": "g / kg",
     "g/kg": "g / kg",
     "mmol m-3": "mmol / $m^{3}$",
@@ -41,4 +41,4 @@ def format_units(units):
     try:
         return STR_LATEX_MAPPING[units]
     except KeyError:
-        raise KeyError("units not found in string to LaTeX mapping: {}".format(units))
+        raise KeyError(f"units not found in string to LaTeX mapping: {units}")

--- a/SalishSeaTools/salishsea_tools/loadDataFRP.py
+++ b/SalishSeaTools/salishsea_tools/loadDataFRP.py
@@ -97,8 +97,8 @@ class dataPair:
 
 def fmtVarName(strx):
     """transform string into one that meets python naming conventions"""
-    vName = re.sub("[^a-zA-Z0-9_\-\s/]", "", strx.strip())
-    vName = re.sub("[\s/]", "_", vName)
+    vName = re.sub(r"[^a-zA-Z0-9_\-\s/]", "", strx.strip())
+    vName = re.sub(r"[\s/]", "_", vName)
     vName = re.sub("-", "_", vName)
     if re.match("[0-9]", vName):
         vName = "_" + vName
@@ -183,18 +183,18 @@ def readcnv(fpath):
     alphnumlist = list(string.ascii_letters) + list(string.digits)
     # define regexes for reading headers:
     reSta = re.compile(
-        "(?<=\*\*\sStation:)\s?([0-9])+\s?"
+        r"(?<=\*\*\sStation:)\s?([0-9])+\s?"
     )  # assumes numeric station identifiers
-    reLat = re.compile("(?<=\*\*\sLatitude\s=)\s?([\-0-9\.]+)\s([\-\.0-9]+)\s?([NS])")
-    reLon = re.compile("(?<=\*\*\sLongitude\s=)\s?([\-0-9\.]+)\s([\-\.0-9]+)\s?([EW])")
+    reLat = re.compile(r"(?<=\*\*\sLatitude\s=)\s?([\-0-9\.]+)\s([\-\.0-9]+)\s?([NS])")
+    reLon = re.compile(r"(?<=\*\*\sLongitude\s=)\s?([\-0-9\.]+)\s([\-\.0-9]+)\s?([EW])")
     # start_time = May 08 2002 09:39:10
-    reST = re.compile("(?<=\#\sstart_time\s=).*")
+    reST = re.compile(r"(?<=\#\sstart_time\s=).*")
     # reTZ=re.compile('(?<=\*\*\s...\s\(Time\)\s=).*')
     # reCr=re.compile('(?<=\*\*\sCruise:).*')
-    reNam = re.compile("(?<=\#\sname\s)([0-9]+)\s=\s(.*)\:\s?(.*)\s?")
+    reNam = re.compile(r"(?<=\#\sname\s)([0-9]+)\s=\s(.*)\:\s?(.*)\s?")
 
     # define regex for finding searching:
-    spStart = re.compile("^\s*[0-9]")  # starts with space characters followed by digit
+    spStart = re.compile(r"^\s*[0-9]")  # starts with space characters followed by digit
 
     headers = list()
     # lineno=0

--- a/SalishSeaTools/salishsea_tools/loadDataFRP.py
+++ b/SalishSeaTools/salishsea_tools/loadDataFRP.py
@@ -1,13 +1,15 @@
-import numpy as np
-import pandas as pd
-from scipy import signal as ssig
-from scipy import stats as spst
 import os
 import re
 import string
-from salishsea_tools import geo_tools
-import netCDF4 as nc
+
 import gsw
+import netCDF4 as nc
+import numpy as np
+import pandas as pd
+from scipy import signal as ssig
+
+from salishsea_tools import geo_tools
+
 
 # list CTD cnv files associated with cast numbers
 cnvlist19 = {

--- a/SalishSeaTools/salishsea_tools/timeseries_tools.py
+++ b/SalishSeaTools/salishsea_tools/timeseries_tools.py
@@ -59,14 +59,14 @@ def load_NEMO_timeseries(
         data = np.concatenate([data, data_trim], axis=0)
 
     # Reshape to grid
-    if shape is "grid":
+    if shape == "grid":
 
         # Correct for depth dimension name
-        if dim.find("depth") is not -1:
+        if dim.find("depth") != -1:
             dim1, dim2, dimslice = "gridY", "gridX", "z"
-        elif dim.find("y") is not -1:
+        elif dim.find("y") != -1:
             dim1, dim2, dimslice = "gridZ", "gridX", "y"
-        elif dim.find("x") is not -1:
+        elif dim.find("x") != -1:
             dim1, dim2, dimslice = "gridZ", "gridY", "x"
 
         # Reshape data to grid
@@ -141,7 +141,7 @@ def reshape_coords(mask_in, dim_in, index=0, spacing=1):
     """
 
     # Correct for depth dimension name
-    if dim_in.find("depth") is not -1:
+    if dim_in.find("depth") != -1:
         dim = "deptht"
     else:
         dim = dim_in

--- a/SalishSeaTools/tests/test_formatting_tools.py
+++ b/SalishSeaTools/tests/test_formatting_tools.py
@@ -1,0 +1,58 @@
+# Copyright 2013 – present by the SalishSeaCast contributors
+# and The University of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for SalishSeaTools formatting_tools module."""
+
+import pytest
+
+from salishsea_tools.formatting_tools import format_units
+
+
+class TestFormatUnits:
+    """Unit tests for the format_units() function."""
+
+    @pytest.mark.parametrize(
+        "units, expected_output",
+        [
+            ("m/s", "m/s"),
+            ("m2/s", "m$^2$ / s$"),
+            ("degrees_east", "$^\\circ$E"),
+            ("degrees_north", "$^\\circ$N"),
+            ("degC", "$^\\circ$C"),
+            ("g kg-1", "g / kg"),
+            ("g/kg", "g / kg"),
+            ("mmol m-3", "mmol / $m^{3}$"),
+            ("mmol/m3", "mmol / $m^{3}$"),
+            ("m2/s3", "m$^2$ / s$^3$"),
+        ],
+    )
+    def test_format_units_valid(self, units, expected_output):
+        """Test valid unit conversion to LaTeX notation."""
+        assert format_units(units) == expected_output
+
+    @pytest.mark.parametrize(
+        "invalid_units",
+        [
+            "invalid_unit",
+            "",
+            None,
+        ],
+    )
+    def test_format_units_invalid(self, invalid_units):
+        """Test invalid unit conversion raises KeyError."""
+        with pytest.raises(
+            KeyError, match=r"units not found in string to LaTeX mapping"
+        ):
+            format_units(invalid_units)


### PR DESCRIPTION
* Fixed deprecated syntax for string and integer comparisons
* Fixed single `\` characters in LaTeX strings
* Replaced plain string literals with raw string literals (prefix `r`) in regex patterns

Also:
* Added unit tests for `formatting_tools` module
* Cleaned up imports in `loadDataFRP` module
* Improved top of module docs in `loadDataFRP` module